### PR TITLE
Fixed navigation issues

### DIFF
--- a/src/org/bigbluebutton/command/NavigateToCommand.as
+++ b/src/org/bigbluebutton/command/NavigateToCommand.as
@@ -16,17 +16,20 @@ package org.bigbluebutton.command
 		[Inject]
 		public var details: Object;
 		
+		[Inject]
+		public var transitionAnimation: int;
+		
 		override public function execute():void
 		{
 			if(to == null || to == "") throw new Error("NavigateTo should not be empty");
 			
 			if(to == PagesENUM.LAST)
 			{
-				userUISession.popPage();
+				userUISession.popPage(transitionAnimation);
 			}
 			else
 			{
-				userUISession.pushPage(to, details);
+				userUISession.pushPage(to, details, transitionAnimation);
 			}
 			
 			

--- a/src/org/bigbluebutton/command/NavigateToSignal.as
+++ b/src/org/bigbluebutton/command/NavigateToSignal.as
@@ -6,7 +6,7 @@ package org.bigbluebutton.command
 	{
 		public function NavigateToSignal()
 		{
-			super(String, Object);
+			super(String, Object, int);
 		}
 	}
 }

--- a/src/org/bigbluebutton/model/IUserUISession.as
+++ b/src/org/bigbluebutton/model/IUserUISession.as
@@ -1,5 +1,6 @@
 package org.bigbluebutton.model
 {
+	import org.bigbluebutton.view.navigation.pages.TransitionAnimationENUM;
 	import org.osflash.signals.ISignal;
 
 	public interface IUserUISession
@@ -11,8 +12,8 @@ package org.bigbluebutton.model
 		
 		function get currentPage():String;
 		function get lastPage():String;
-		function popPage():void	;
-		function pushPage(value:String, details:Object = null):void;
+		function popPage(animation:int = TransitionAnimationENUM.APPEAR):void;
+		function pushPage(value:String, details:Object = null, animation:int = TransitionAnimationENUM.APPEAR):void;
 		function get currentPageDetails():Object;
 		function get loading():Boolean;
 		function set loading(value:Boolean):void;		

--- a/src/org/bigbluebutton/model/UserUISession.as
+++ b/src/org/bigbluebutton/model/UserUISession.as
@@ -2,6 +2,7 @@ package org.bigbluebutton.model
 {
 	import mx.collections.ArrayList;
 	
+	import org.bigbluebutton.view.navigation.pages.TransitionAnimationENUM;
 	import org.osflash.signals.ISignal;
 	import org.osflash.signals.Signal;
 	
@@ -81,23 +82,23 @@ package org.bigbluebutton.model
 		
 		
 		
-		public function pushPage(value:String, details:Object = null):void
+		public function pushPage(value:String, details:Object = null, animation:int = TransitionAnimationENUM.APPEAR):void
 		{
 			if(value != currentPage)
 			{
 				_listPages.addItem({value:value, details:details});
 				var removeView:Boolean = false;
-				_pageChangedSignal.dispatch(currentPage, removeView);
+				_pageChangedSignal.dispatch(currentPage, removeView, animation);
 			}
 		}
 		
-		public function popPage():void
+		public function popPage(animation:int = TransitionAnimationENUM.APPEAR):void
 		{
 			if(_listPages.length > 0)
 			{
 				_listPages.removeItemAt(_listPages.length-1);
 				var removeView:Boolean = true;
-				_pageChangedSignal.dispatch(currentPage, removeView);
+				_pageChangedSignal.dispatch(currentPage, removeView, animation);
 			}				
 		}
 		

--- a/src/org/bigbluebutton/view/navigation/IPagesNavigatorView.as
+++ b/src/org/bigbluebutton/view/navigation/IPagesNavigatorView.as
@@ -15,5 +15,6 @@ package org.bigbluebutton.view.navigation
 			
 		function set visible(value:Boolean):void
 		function set includeInLayout(value:Boolean):void
+		function popAll(transition:ViewTransitionBase = null):void
 	}
 }

--- a/src/org/bigbluebutton/view/navigation/PagesNavigatorViewMediator.as
+++ b/src/org/bigbluebutton/view/navigation/PagesNavigatorViewMediator.as
@@ -5,11 +5,14 @@ package org.bigbluebutton.view.navigation
 	import org.bigbluebutton.model.IUserUISession;
 	import org.bigbluebutton.util.NoTransition;
 	import org.bigbluebutton.view.navigation.pages.PagesENUM;
+	import org.bigbluebutton.view.navigation.pages.TransitionAnimationENUM;
 	import org.osmf.logging.Log;
 	
 	import robotlegs.bender.bundles.mvcs.Mediator;
 	
 	import spark.components.ViewNavigator;
+	import spark.effects.CrossFade;
+	import spark.transitions.CrossFadeViewTransition;
 	import spark.transitions.SlideViewTransition;
 	import spark.transitions.ViewTransitionBase;
 	import spark.transitions.ViewTransitionDirection;
@@ -18,10 +21,7 @@ package org.bigbluebutton.view.navigation
 	{
 		[Inject]
 		public var view: IPagesNavigatorView;
-		
-		[Inject]
-		public var userSession: IUserUISession
-		
+			
 		[Inject]
 		public var userUISession: IUserUISession
 		
@@ -29,33 +29,58 @@ package org.bigbluebutton.view.navigation
 		{
 			Log.getLogger("org.bigbluebutton").info(String(this));
 			
-			userSession.pageChangedSignal.add(changePage);
+			userUISession.pageChangedSignal.add(changePage);
 			
 			userUISession.pushPage(PagesENUM.LOGIN);
 		}
 		
-		protected function changePage(pageName:String, pageRemoved:Boolean = false, transition:ViewTransitionBase = null):void
+		protected function changePage(pageName:String, pageRemoved:Boolean = false, animation:int = TransitionAnimationENUM.APPEAR, transition:ViewTransitionBase = null):void
 		{			
-			if(pageRemoved)
+			switch(animation)
 			{
-				if(transition == null) {
-					var slideRight:SlideViewTransition = new SlideViewTransition();
-					slideRight.duration = 300;
-					slideRight.direction = ViewTransitionDirection.RIGHT;
-					slideRight.addEventListener(FlexEvent.TRANSITION_START, onTransitionStart);
-					transition = slideRight;
+				case TransitionAnimationENUM.APPEAR:
+				{
+					var appear:CrossFadeViewTransition = new CrossFadeViewTransition;
+					appear.duration = 50;
+					appear.addEventListener(FlexEvent.TRANSITION_START, onTransitionStart);
+					transition = appear;
+					break;
 				}
-				view.popView();
-			}
-			else if(pageName != null && pageName != "") 
-			{
-				if(transition == null) {
+				case TransitionAnimationENUM.SLIDE_LEFT:
+				{
 					var slideLeft:SlideViewTransition = new SlideViewTransition();
 					slideLeft.duration = 300;
 					slideLeft.direction = ViewTransitionDirection.LEFT;
 					slideLeft.addEventListener(FlexEvent.TRANSITION_START, onTransitionStart);
 					transition = slideLeft;
+					break;
 				}
+				case TransitionAnimationENUM.SLIDE_RIGHT:
+				{
+					var slideRight:SlideViewTransition = new SlideViewTransition();
+					slideRight.duration = 300;
+					slideRight.direction = ViewTransitionDirection.RIGHT;
+					slideRight.addEventListener(FlexEvent.TRANSITION_START, onTransitionStart);
+					transition = slideRight;
+					break;
+				}
+				default:
+				{
+					break;
+				}
+			}
+			
+			if(pageName == PagesENUM.PARTICIPANTS || pageName == PagesENUM.PRESENTATION || pageName == PagesENUM.VIDEO_CHAT || pageName == PagesENUM.CHATROOMS)
+			{
+				view.popAll();
+				view.pushView(PagesENUM.getClassfromName(pageName), null, null, transition);
+			}
+			else if(pageRemoved)
+			{
+				view.popView(transition);
+			}
+			else if(pageName != null && pageName != "") 
+			{
 				view.pushView(PagesENUM.getClassfromName(pageName), null, null, transition);
 			}
 		}

--- a/src/org/bigbluebutton/view/navigation/pages/TransitionAnimationENUM.as
+++ b/src/org/bigbluebutton/view/navigation/pages/TransitionAnimationENUM.as
@@ -1,0 +1,10 @@
+package org.bigbluebutton.view.navigation.pages
+{
+	public class TransitionAnimationENUM
+	{
+		// the type of animation when a view changes:
+		public static const APPEAR:int = 0;
+		public static const SLIDE_RIGHT:int = 1;
+		public static const SLIDE_LEFT:int = 2;
+	}
+}

--- a/src/org/bigbluebutton/view/navigation/pages/chatrooms/ChatRoomsViewMediator.as
+++ b/src/org/bigbluebutton/view/navigation/pages/chatrooms/ChatRoomsViewMediator.as
@@ -22,6 +22,7 @@ package org.bigbluebutton.view.navigation.pages.chatrooms
 	import org.bigbluebutton.model.chat.IChatMessagesSession;
 	import org.bigbluebutton.model.chat.PrivateChatMessage;
 	import org.bigbluebutton.view.navigation.pages.PagesENUM;
+	import org.bigbluebutton.view.navigation.pages.TransitionAnimationENUM;
 	import org.osflash.signals.ISignal;
 	import org.osmf.logging.Log;
 	
@@ -262,11 +263,11 @@ package org.bigbluebutton.view.navigation.pages.chatrooms
 			{
 				if(item.hasOwnProperty("button"))
 				{
-					userUISession.pushPage(PagesENUM.SELECT_PARTICIPANT, item)
+					userUISession.pushPage(PagesENUM.SELECT_PARTICIPANT, item, TransitionAnimationENUM.SLIDE_LEFT)
 				}
 				else
 				{
-					userUISession.pushPage(PagesENUM.CHAT, item)
+					userUISession.pushPage(PagesENUM.CHAT, item, TransitionAnimationENUM.SLIDE_LEFT)
 				}
 			}
 			else

--- a/src/org/bigbluebutton/view/navigation/pages/participants/ParticipantsViewMediator.as
+++ b/src/org/bigbluebutton/view/navigation/pages/participants/ParticipantsViewMediator.as
@@ -13,6 +13,7 @@ package org.bigbluebutton.view.navigation.pages.participants
 	import org.bigbluebutton.model.User;
 	import org.bigbluebutton.model.UserList;
 	import org.bigbluebutton.view.navigation.pages.PagesENUM;
+	import org.bigbluebutton.view.navigation.pages.TransitionAnimationENUM;
 	import org.osflash.signals.ISignal;
 	import org.osflash.signals.Signal;
 	import org.osmf.logging.Log;
@@ -85,7 +86,7 @@ package org.bigbluebutton.view.navigation.pages.participants
 		{
 			if (event.newIndex >= 0) {
 				var user:User = dataProvider.getItemAt(event.newIndex) as User;
-				userUISession.pushPage(PagesENUM.USER_DETAIS, user);
+				userUISession.pushPage(PagesENUM.USER_DETAIS, user, TransitionAnimationENUM.SLIDE_LEFT);
 			}
 		}
 			

--- a/src/org/bigbluebutton/view/navigation/pages/selectparticipant/SelectParticipantViewMediator.as
+++ b/src/org/bigbluebutton/view/navigation/pages/selectparticipant/SelectParticipantViewMediator.as
@@ -11,6 +11,7 @@ package org.bigbluebutton.view.navigation.pages.selectparticipant
 	import org.bigbluebutton.model.IUserUISession;
 	import org.bigbluebutton.model.User;
 	import org.bigbluebutton.view.navigation.pages.PagesENUM;
+	import org.bigbluebutton.view.navigation.pages.TransitionAnimationENUM;
 	import org.osflash.signals.ISignal;
 	import org.osmf.logging.Log;
 	
@@ -85,7 +86,7 @@ package org.bigbluebutton.view.navigation.pages.selectparticipant
 		protected function onSelectUser(event:IndexChangeEvent):void
 		{
 			var user:User = dataProvider.getItemAt(event.newIndex) as User;
-			userUISession.pushPage(PagesENUM.CHAT, user);
+			userUISession.pushPage(PagesENUM.CHAT, user, TransitionAnimationENUM.SLIDE_LEFT);
 		}
 		
 		override public function destroy():void

--- a/src/org/bigbluebutton/view/navigation/pages/userdetails/UserDetaisViewMediator.as
+++ b/src/org/bigbluebutton/view/navigation/pages/userdetails/UserDetaisViewMediator.as
@@ -3,10 +3,13 @@ package org.bigbluebutton.view.navigation.pages.userdetails
 	import flash.display.DisplayObject;
 	import flash.events.MouseEvent;
 	
+	import mx.states.Transition;
+	
 	import org.bigbluebutton.model.IUserSession;
 	import org.bigbluebutton.model.IUserUISession;
 	import org.bigbluebutton.model.User;
 	import org.bigbluebutton.view.navigation.pages.PagesENUM;
+	import org.bigbluebutton.view.navigation.pages.TransitionAnimationENUM;
 	import org.osmf.logging.Log;
 	
 	import robotlegs.bender.bundles.mvcs.Mediator;
@@ -41,12 +44,12 @@ package org.bigbluebutton.view.navigation.pages.userdetails
 		
 		protected function onShowCameraButton(event:MouseEvent):void
 		{
-			userUISession.pushPage(PagesENUM.VIDEO_CHAT, _user);
+			userUISession.pushPage(PagesENUM.VIDEO_CHAT, _user, TransitionAnimationENUM.APPEAR);
 		}
 		
 		protected function onShowPrivateChatButton(event:MouseEvent):void
 		{
-			userUISession.pushPage(PagesENUM.CHAT, _user);
+			userUISession.pushPage(PagesENUM.CHAT, _user, TransitionAnimationENUM.APPEAR);
 		}
 		
 		private function userRemoved(userID:String):void

--- a/src/org/bigbluebutton/view/ui/BackButton.mxml
+++ b/src/org/bigbluebutton/view/ui/BackButton.mxml
@@ -6,10 +6,13 @@
 					 width="30" height="30" 
 					 buttonMode="true"
 					 mouseEnabled="true"
-					 navigateTo="{PagesENUM.LAST}">
+					 navigateTo="{PagesENUM.LAST}"
+					 transitionAnimation="{TransitionAnimationENUM.SLIDE_RIGHT}"
+					 >
 	<fx:Script>
 		<![CDATA[
 			import org.bigbluebutton.view.navigation.pages.PagesENUM;
+			import org.bigbluebutton.view.navigation.pages.TransitionAnimationENUM;
 		]]>
 	</fx:Script>
 	<fx:Declarations>

--- a/src/org/bigbluebutton/view/ui/INavigationButton.as
+++ b/src/org/bigbluebutton/view/ui/INavigationButton.as
@@ -9,7 +9,10 @@ package org.bigbluebutton.view.ui
 	{
 		function get navigationSignal(): ISignal
 			
-		function get navigateTo():String
+		function get transitionAnimation():int
+		function set transitionAnimation(value:int):void
+			
+		function get navigateTo():String;
 		function set navigateTo(value:String):void
 			
 		function get pageDetails():String

--- a/src/org/bigbluebutton/view/ui/MenuChatButton.mxml
+++ b/src/org/bigbluebutton/view/ui/MenuChatButton.mxml
@@ -6,11 +6,17 @@
 		 width="80" height="42"
 		 buttonMode="true"
 		 mouseEnabled="true" 
+		 transitionAnimation="{TransitionAnimationENUM.APPEAR}"
 		 >
 	<ui:states>
 		<s:State name="unselected"/>
 		<s:State name="selected"/>
 	</ui:states>
+	<fx:Script>
+		<![CDATA[
+			import org.bigbluebutton.view.navigation.pages.TransitionAnimationENUM;
+		]]>
+	</fx:Script>
 	<fx:Declarations>
 		<!-- Place non-visual elements (e.g., services, value objects) here -->
 	</fx:Declarations>

--- a/src/org/bigbluebutton/view/ui/MenuParticipantsButton.mxml
+++ b/src/org/bigbluebutton/view/ui/MenuParticipantsButton.mxml
@@ -5,12 +5,18 @@
 					 xmlns:assets="assets.*"
 					 width="80" height="42"
 					 buttonMode="true"
-					 mouseEnabled="true" 
+					 mouseEnabled="true"
+					 transitionAnimation="{TransitionAnimationENUM.APPEAR}"
 					 >
 	<ui:states>
 		<s:State name="unselected"/>
 		<s:State name="selected"/>
 	</ui:states>
+	<fx:Script>
+		<![CDATA[
+			import org.bigbluebutton.view.navigation.pages.TransitionAnimationENUM;
+		]]>
+	</fx:Script>
 	<fx:Declarations>
 		<!-- Place non-visual elements (e.g., services, value objects) here -->
 	</fx:Declarations>

--- a/src/org/bigbluebutton/view/ui/MenuPresentationButton.mxml
+++ b/src/org/bigbluebutton/view/ui/MenuPresentationButton.mxml
@@ -5,12 +5,18 @@
 					 xmlns:assets="assets.*"
 					 width="80" height="42"
 					 buttonMode="true"
-					 mouseEnabled="true" 
+					 mouseEnabled="true"
+					 transitionAnimation="{TransitionAnimationENUM.APPEAR}"
 					 >
 	<ui:states>
 		<s:State name="unselected"/>
 		<s:State name="selected"/>
 	</ui:states>
+	<fx:Script>
+		<![CDATA[
+			import org.bigbluebutton.view.navigation.pages.TransitionAnimationENUM;
+		]]>
+	</fx:Script>
 	<fx:Declarations>
 		<!-- Place non-visual elements (e.g., services, value objects) here -->
 	</fx:Declarations>

--- a/src/org/bigbluebutton/view/ui/MenuVideoChatButton.mxml
+++ b/src/org/bigbluebutton/view/ui/MenuVideoChatButton.mxml
@@ -6,11 +6,17 @@
 					 width="80" height="42"
 					 buttonMode="true"
 					 mouseEnabled="true" 
+					 transitionAnimation="{TransitionAnimationENUM.APPEAR}"
 					 >
 	<ui:states>
 		<s:State name="unselected"/>
 		<s:State name="selected"/>
 	</ui:states>
+	<fx:Script>
+		<![CDATA[
+			import org.bigbluebutton.view.navigation.pages.TransitionAnimationENUM;
+		]]>
+	</fx:Script>
 	<fx:Declarations>
 		<!-- Place non-visual elements (e.g., services, value objects) here -->
 	</fx:Declarations>

--- a/src/org/bigbluebutton/view/ui/NavigationButton.as
+++ b/src/org/bigbluebutton/view/ui/NavigationButton.as
@@ -9,6 +9,18 @@ package org.bigbluebutton.view.ui
 	
 	public class NavigationButton extends Group implements INavigationButton
 	{		
+		private var _transitionAnimation:int;
+			
+		public function get transitionAnimation():int
+		{
+			return _transitionAnimation;	
+		}
+		
+		public function set transitionAnimation(value:int):void
+		{
+			_transitionAnimation = value;
+		}
+		
 		private var _navigationSignal: Signal = new Signal();
 		
 		/**

--- a/src/org/bigbluebutton/view/ui/NavigationButtonMediator.as
+++ b/src/org/bigbluebutton/view/ui/NavigationButtonMediator.as
@@ -4,6 +4,7 @@ package org.bigbluebutton.view.ui
 	
 	import org.bigbluebutton.command.NavigateToSignal;
 	import org.bigbluebutton.model.IUserUISession;
+	import org.bigbluebutton.view.navigation.pages.TransitionAnimationENUM;
 	
 	import robotlegs.bender.bundles.mvcs.Mediator;
 	
@@ -46,13 +47,13 @@ package org.bigbluebutton.view.ui
 		 */
 		private function navigate(): void
 		{
-			navigateToPageSignal.dispatch(view.navigateTo, view.pageDetails);
+			navigateToPageSignal.dispatch(view.navigateTo, view.pageDetails, view.transitionAnimation);
 		}
 		
 		/**
 		 * Update the view when there is a chenge in the model
 		 */ 
-		private function update(page:String, action:Boolean = false):void
+		private function update(page:String, action:Boolean = false, animation:int = TransitionAnimationENUM.APPEAR):void
 		{
 			if(view.navigateTo == page)
 			{

--- a/src/org/bigbluebutton/view/ui/ProfileButton.mxml
+++ b/src/org/bigbluebutton/view/ui/ProfileButton.mxml
@@ -6,7 +6,8 @@
 					 width="30" height="30" 
 					 buttonMode="true"
 					 mouseEnabled="true"
-					 navigateTo="{PagesENUM.PROFILE}">
+					 navigateTo="{PagesENUM.PROFILE}"
+					 transitionAnimation="{TransitionAnimationENUM.SLIDE_LEFT}">
 	<ui:states>
 		<s:State name="unselected"/>
 		<s:State name="selected"/>
@@ -14,6 +15,7 @@
 	<fx:Script>
 		<![CDATA[
 			import org.bigbluebutton.view.navigation.pages.PagesENUM;
+			import org.bigbluebutton.view.navigation.pages.TransitionAnimationENUM;
 		]]>
 	</fx:Script>
 	<fx:Declarations>


### PR DESCRIPTION
Fixed page transition animations (before, they were all sliding animations).

Added an "_transitionAnimation" property to buttons so that now the transition animation that happens will be determined by that property of the button.

When switching tabs, all views on the ViewNavigator stack will get popped off.
