### PR TITLE
Three small bugs

### DIFF
--- a/src/org/bigbluebutton/core/DeskshareConnection.as
+++ b/src/org/bigbluebutton/core/DeskshareConnection.as
@@ -80,7 +80,8 @@ package org.bigbluebutton.core
 					{
 						trace("Error while trying to call remote method on the server");
 					}
-				)
+				),
+				_room
 			);
 	
 		}

--- a/src/org/bigbluebutton/model/UserList.as
+++ b/src/org/bigbluebutton/model/UserList.as
@@ -339,6 +339,7 @@ package org.bigbluebutton.model
 		public function userLeaveAudio(userID:String):void {
 			var user:User = getUser(userID);
 			if(user != null) {
+				user.talking = false;
 				user.voiceJoined = false;
 				
 				userChangeSignal.dispatch(user, JOIN_AUDIO);

--- a/src/org/bigbluebutton/view/navigation/pages/disconnect/DisconnectPageViewMediator.as
+++ b/src/org/bigbluebutton/view/navigation/pages/disconnect/DisconnectPageViewMediator.as
@@ -3,6 +3,7 @@ package org.bigbluebutton.view.navigation.pages.disconnect
 	import flash.desktop.NativeApplication;
 	import flash.events.Event;
 	import flash.events.MouseEvent;
+	import flash.system.Capabilities;
 	
 	import mx.core.FlexGlobals;
 	
@@ -23,7 +24,14 @@ package org.bigbluebutton.view.navigation.pages.disconnect
 			
 		override public function initialize():void
 		{
-			view.exitButton.addEventListener(MouseEvent.CLICK, applicationExit);
+			// If operating system is iOS, don't show exit button because there is no way to exit application:
+			if(Capabilities.os.search("iPhone") >= 0) {
+				view.exitButton.visible = false;
+			}
+			else {
+				view.exitButton.addEventListener(MouseEvent.CLICK, applicationExit);
+			}
+			
 			changeConnectionStatus(userUISession.currentPageDetails as int);
 			FlexGlobals.topLevelApplication.pageName.text = "";
 			FlexGlobals.topLevelApplication.topActionBar.visible = false;


### PR DESCRIPTION
Three small bugs:
1. If the presenter was already sharing his desktop, and then a mobile client joined, the mobile client would not pick up the desk share stream (I introduced this bug when rewriting the services).
2. "Exit" button would show on iOS devices, even though there is no way to exit the application. This has been removed on iOS devices.
3. If a user left voice while still talking, the talking icon would remain.
